### PR TITLE
Erstatt fiktive fødselsnummer med syntetisk fnr

### DIFF
--- a/src/test/kotlin/no/nav/omsorgspenger/personopplysninger/HentPersonopplysningerTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/personopplysninger/HentPersonopplysningerTest.kt
@@ -173,12 +173,12 @@ internal class HentPersonopplysningerTest(
 
     @Test
     fun `Sender med tom lösning på person utan alla behovsattribut`() {
-        val (_, behovssekvens) = nyBehovsSekvens(setOf("21108424238"))
+        val (_, behovssekvens) = nyBehovsSekvens(setOf("14430175875"))
         rapid.sendTestMessage(behovssekvens)
 
         val resultat = rapid.inspektør.message(0)["@løsninger"]["HentPersonopplysninger"]["personopplysninger"].toString()
 
-        assertFalse(resultat.contains("21108424238"))
+        assertFalse(resultat.contains("14430175875"))
     }
 
     @Test

--- a/src/test/kotlin/no/nav/omsorgspenger/personopplysninger/RelasjonMediatorTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/personopplysninger/RelasjonMediatorTest.kt
@@ -16,14 +16,14 @@ internal class RelasjonMediatorTest {
     fun `Mor med barn + man med barn från tidigare førhållanden`() {
         val resultat = runBlocking {
             relasjonMediator.hentRelasjoner(
-                identitetsnummer = "08027622446",
-                til = setOf("24021350083", "29087623775"),
+                identitetsnummer = "24420167209",
+                til = setOf("26470392885", "14510058187"),
                 correlationId = "familie1"
             )
         }
 
-        val barn = "{relasjon=BARN, identitetsnummer=24021350083, borSammen=true}"
-        val far = "{relasjon=INGEN, identitetsnummer=29087623775, borSammen=false}"
+        val barn = "{relasjon=BARN, identitetsnummer=26470392885, borSammen=true}"
+        val far = "{relasjon=INGEN, identitetsnummer=14510058187, borSammen=false}"
 
         assert(resultat.toString().contains(barn)) { "Forventet: $barn i resultat: \n $resultat" }
         assert(resultat.toString().contains(far)) { "Forventet: $far i resultat: \n $resultat" }
@@ -33,14 +33,14 @@ internal class RelasjonMediatorTest {
     fun `Mor med barn på delt bosted og far på kontaktadresse`() {
         val resultat = runBlocking {
             relasjonMediator.hentRelasjoner(
-                identitetsnummer = "08027622446",
-                til = setOf("24021350083", "29087623775"),
+                identitetsnummer = "24420167209",
+                til = setOf("26470392885", "14510058187"),
                 correlationId = "familie2"
             )
         }
 
-        val barn = "{relasjon=BARN, identitetsnummer=24021350083, borSammen=true}"
-        val far = "{relasjon=INGEN, identitetsnummer=29087623775, borSammen=true}"
+        val barn = "{relasjon=BARN, identitetsnummer=26470392885, borSammen=true}"
+        val far = "{relasjon=INGEN, identitetsnummer=14510058187, borSammen=true}"
 
         assert(resultat.toString().contains(barn)) { "Forventet: $barn i resultat: \n $resultat" }
         assert(resultat.toString().contains(far)) { "Forventet: $far i resultat: \n $resultat" }
@@ -50,15 +50,15 @@ internal class RelasjonMediatorTest {
     fun `Mor med et barn på delt bosted, et på postadresse i fritt format og far på oppholdsadresse`() {
         val resultat = runBlocking {
             relasjonMediator.hentRelasjoner(
-                identitetsnummer = "08027622446",
-                til = setOf("24021350083", "24021350084", "29087623775"),
+                identitetsnummer = "24420167209",
+                til = setOf("26470392885", "15490357286", "14510058187"),
                 correlationId = "familie3"
             )
         }
 
-        val barn1 = "{relasjon=BARN, identitetsnummer=24021350083, borSammen=true}"
-        val barn2 = "{relasjon=BARN, identitetsnummer=24021350084, borSammen=true}"
-        val far = "{relasjon=INGEN, identitetsnummer=29087623775, borSammen=true}"
+        val barn1 = "{relasjon=BARN, identitetsnummer=26470392885, borSammen=true}"
+        val barn2 = "{relasjon=BARN, identitetsnummer=15490357286, borSammen=true}"
+        val far = "{relasjon=INGEN, identitetsnummer=14510058187, borSammen=true}"
 
         assert(resultat.toString().contains(barn1)) { "Forventet: $barn1 i resultat: \n $resultat" }
         assert(resultat.toString().contains(barn2)) { "Forventet: $barn2 i resultat: \n $resultat" }

--- a/src/test/kotlin/no/nav/omsorgspenger/testutils/wiremock/PdlApiMock.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/testutils/wiremock/PdlApiMock.kt
@@ -146,7 +146,7 @@ private fun WireMockServer.stubPdlApiPersonUtenPersonInfo(): WireMockServer {
         )
             .withHeader("Authorization", containing("Bearer"))
             .withHeader("Content-Type", equalTo("application/json"))
-            .withRequestBody(matchingJsonPath("$.variables.identer", containing("21108424238")))
+            .withRequestBody(matchingJsonPath("$.variables.identer", containing("14430175875")))
             .willReturn(
                 WireMock.aResponse()
                     .withStatus(200)
@@ -157,7 +157,7 @@ private fun WireMockServer.stubPdlApiPersonUtenPersonInfo(): WireMockServer {
                                           "data": {
                                             "hentPersonBolk": [
                                               {
-                                                "ident": "21108424238",
+                                                "ident": "14430175875",
                                                 "person": {
                                                   "navn": [],
                                                   "foedsel": [],
@@ -168,10 +168,10 @@ private fun WireMockServer.stubPdlApiPersonUtenPersonInfo(): WireMockServer {
                                             ],
                                             "hentIdenterBolk": [
                                               {
-                                                "ident": "21108424238",
+                                                "ident": "14430175875",
                                                 "identer": [
                                                   {
-                                                    "ident": "21108424238",
+                                                    "ident": "14430175875",
                                                     "gruppe": "FOLKEREGISTERIDENT"
                                                   },
                                                   {

--- a/src/test/resources/pdl/test1-familie.json
+++ b/src/test/resources/pdl/test1-familie.json
@@ -2,11 +2,11 @@
   "data": {
     "hentPersonBolk": [
       {
-        "ident": "08027622446",
+        "ident": "24420167209",
         "person": {
           "forelderBarnRelasjon": [
             {
-              "relatertPersonsIdent": "24021350083",
+              "relatertPersonsIdent": "26470392885",
               "relatertPersonsRolle": "BARN",
               "minRolleForPerson": "MOR"
             }
@@ -24,11 +24,11 @@
         "code": "ok"
       },
       {
-        "ident": "24021350083",
+        "ident": "26470392885",
         "person": {
           "forelderBarnRelasjon": [
             {
-              "relatertPersonsIdent": "08027622446",
+              "relatertPersonsIdent": "24420167209",
               "relatertPersonsRolle": "MOR",
               "minRolleForPerson": "BARN"
             }
@@ -46,21 +46,21 @@
         "code": "ok"
       },
       {
-        "ident": "29087623775",
+        "ident": "14510058187",
         "person": {
           "forelderBarnRelasjon": [
             {
-              "relatertPersonsIdent": "01041450025",
+              "relatertPersonsIdent": "17420373147",
               "relatertPersonsRolle": "BARN",
               "minRolleForPerson": "FAR"
             },
             {
-              "relatertPersonsIdent": "11081350126",
+              "relatertPersonsIdent": "18410162721",
               "relatertPersonsRolle": "BARN",
               "minRolleForPerson": "FAR"
             },
             {
-              "relatertPersonsIdent": "27121950125",
+              "relatertPersonsIdent": "11410183759",
               "relatertPersonsRolle": "BARN",
               "minRolleForPerson": "FAR"
             }

--- a/src/test/resources/pdl/test2-familie.json
+++ b/src/test/resources/pdl/test2-familie.json
@@ -2,11 +2,11 @@
   "data": {
     "hentPersonBolk": [
       {
-        "ident": "08027622446",
+        "ident": "24420167209",
         "person": {
           "forelderBarnRelasjon": [
             {
-              "relatertPersonsIdent": "24021350083",
+              "relatertPersonsIdent": "26470392885",
               "relatertPersonsRolle": "BARN",
               "minRolleForPerson": "MOR"
             }
@@ -24,11 +24,11 @@
         "code": "ok"
       },
       {
-        "ident": "24021350083",
+        "ident": "26470392885",
         "person": {
           "forelderBarnRelasjon": [
             {
-              "relatertPersonsIdent": "08027622446",
+              "relatertPersonsIdent": "24420167209",
               "relatertPersonsRolle": "MOR",
               "minRolleForPerson": "BARN"
             }
@@ -53,21 +53,21 @@
         "code": "ok"
       },
       {
-        "ident": "29087623775",
+        "ident": "14510058187",
         "person": {
           "forelderBarnRelasjon": [
             {
-              "relatertPersonsIdent": "01041450025",
+              "relatertPersonsIdent": "17420373147",
               "relatertPersonsRolle": "BARN",
               "minRolleForPerson": "FAR"
             },
             {
-              "relatertPersonsIdent": "11081350126",
+              "relatertPersonsIdent": "18410162721",
               "relatertPersonsRolle": "BARN",
               "minRolleForPerson": "FAR"
             },
             {
-              "relatertPersonsIdent": "27121950125",
+              "relatertPersonsIdent": "11410183759",
               "relatertPersonsRolle": "BARN",
               "minRolleForPerson": "FAR"
             }

--- a/src/test/resources/pdl/test3-familie.json
+++ b/src/test/resources/pdl/test3-familie.json
@@ -2,11 +2,11 @@
   "data": {
     "hentPersonBolk": [
       {
-        "ident": "08027622446",
+        "ident": "24420167209",
         "person": {
           "forelderBarnRelasjon": [
             {
-              "relatertPersonsIdent": "24021350083",
+              "relatertPersonsIdent": "26470392885",
               "relatertPersonsRolle": "BARN",
               "minRolleForPerson": "MOR"
             }
@@ -24,11 +24,11 @@
         "code": "ok"
       },
       {
-        "ident": "24021350083",
+        "ident": "26470392885",
         "person": {
           "forelderBarnRelasjon": [
             {
-              "relatertPersonsIdent": "08027622446",
+              "relatertPersonsIdent": "24420167209",
               "relatertPersonsRolle": "MOR",
               "minRolleForPerson": "BARN"
             }
@@ -53,11 +53,11 @@
         "code": "ok"
       },
       {
-        "ident": "24021350084",
+        "ident": "15490357286",
         "person": {
           "forelderBarnRelasjon": [
             {
-              "relatertPersonsIdent": "08027622446",
+              "relatertPersonsIdent": "24420167209",
               "relatertPersonsRolle": "MOR",
               "minRolleForPerson": "BARN"
             }
@@ -73,21 +73,21 @@
         "code": "ok"
       },
       {
-        "ident": "29087623775",
+        "ident": "14510058187",
         "person": {
           "forelderBarnRelasjon": [
             {
-              "relatertPersonsIdent": "01041450025",
+              "relatertPersonsIdent": "17420373147",
               "relatertPersonsRolle": "BARN",
               "minRolleForPerson": "FAR"
             },
             {
-              "relatertPersonsIdent": "11081350126",
+              "relatertPersonsIdent": "18410162721",
               "relatertPersonsRolle": "BARN",
               "minRolleForPerson": "FAR"
             },
             {
-              "relatertPersonsIdent": "27121950125",
+              "relatertPersonsIdent": "11410183759",
               "relatertPersonsRolle": "BARN",
               "minRolleForPerson": "FAR"
             }


### PR DESCRIPTION
Erstatter fiktive fødselsnummer i testkode med syntetiske personnummer (syntetiske personnummer) som ikke matcher ekte personer.